### PR TITLE
Fix freeing of the content model by making use of `XML_FreeContentModel`

### DIFF
--- a/Expat/Expat.xs
+++ b/Expat/Expat.xs
@@ -741,7 +741,7 @@ elementDecl(void *data,
 
   cmod = generate_model(model);
 
-  Safefree(model);
+  XML_FreeContentModel(cbv->p, model);
   PUSHMARK(sp);
   EXTEND(sp, 3);
   PUSHs(cbv->self_sv);


### PR DESCRIPTION
This ensures that any wrapping applied to `XML_Memory_Handling_Suite.free_fcn` inside of Expat (e.g. adding/subtracting a constant offset to/from the pointers passed) is not bypassed but respected.

Related documentation:
- https://libexpat.github.io/doc/api/latest/#XML_SetElementDeclHandler
- https://libexpat.github.io/doc/api/latest/#XML_FreeContentModel